### PR TITLE
Added several channels and HD channels

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -103,17 +103,16 @@ addEntertainChannel ('rtp://@239.35.10.5:10000', 'ZDF', year='1963', plot=langua
 # -- Dritte
 addEntertainChannel ('rtp://@239.35.10.13:10000', 'BR Nord', year='1949', genre=language(30091), plot=language(30103), all='BR.jpg')
 addEntertainChannel ('rtp://@239.35.10.7:10000', 'BR Süd', year='1949', genre=language(30091), plot=language(30103), all='BR.jpg', hdurl='rtp://@239.35.10.49:10000')
-addEntertainChannel ('rtp://@239.35.10.8:10000', 'hr-fernsehen', genre=language(30091), plot=language(30124), all='hr.jpg')
-addEntertainChannel ('rtp://@239.35.10.9:10000', 'MDR Sachsen', year='1992', genre=language(30091), plot=language(30104), all='mdr.jpg')
+addEntertainChannel ('rtp://@239.35.10.8:10000', 'hr-fernsehen', genre=language(30091), plot=language(30124), all='hr.jpg', hdurl='rtp://@239.35.10.60:10000')
+addEntertainChannel ('rtp://@239.35.10.9:10000', 'MDR Sachsen', year='1992', genre=language(30091), plot=language(30104), all='mdr.jpg', hdurl='rtp://@239.35.10.61:10000')
 addEntertainChannel ('rtp://@239.35.10.29:10000', 'MDR Sachsen-Anhalt', year='1992', genre=language(30091), plot=language(30104), all='mdr.jpg')
 addEntertainChannel ('rtp://@239.35.10.30:10000', 'MDR Thüringen', year='1992', genre=language(30091), plot=language(30104), all='mdr.jpg')
-addEntertainChannel ('rtp://@239.35.10.10:10000', 'NDR Niedersachsen', year='1954', genre=language(30091), plot=language(30105))
-addEntertainChannel ('rtp://@239.35.10.50:10000', 'NDR Niedersachsen HD', year='1954', genre=language(30091), plot=language(30105))
+addEntertainChannel ('rtp://@239.35.10.10:10000', 'NDR Niedersachsen', year='1954', genre=language(30091), plot=language(30105), hdurl='rtp://@239.35.10.50:10000')
 addEntertainChannel ('rtp://@239.35.10.31:10000', 'NDR Hamburg', year='1954', genre=language(30091), plot=language(30105))
 addEntertainChannel ('rtp://@239.35.10.32:10000', 'NDR Mecklenburg-Vorpommern', year='1954', genre=language(30091), plot=language(30105))
 addEntertainChannel ('rtp://@239.35.10.33:10000', 'NDR Schleswig-Holstein', year='1954', genre=language(30091), plot=language(30105))
 addEntertainChannel ('rtp://@239.35.10.12:10000', 'Radio Bremen TV', year='1945', genre=language(30091), plot=language(30106))
-addEntertainChannel ('rtp://@239.35.10.14:10000', 'rbb Berlin', year='2003', genre=language(30091), plot=language(30107))
+addEntertainChannel ('rtp://@239.35.10.14:10000', 'rbb Berlin', year='2003', genre=language(30091), plot=language(30107), hdurl='rtp://@239.35.10.62:10000')
 addEntertainChannel ('rtp://@239.35.10.34:10000', 'rbb Brandenburg', year='2003', genre=language(30091), plot=language(30107))
 addEntertainChannel ('rtp://@239.35.10.15:10000', 'SR Fernsehen', year='1957', genre=language(30091), plot=language(30108))
 addEntertainChannel ('rtp://@239.35.10.16:10000', 'SWR Baden-Würtenberg', year='1998', genre=language(30091), plot=language(30109), hdurl='rtp://@239.35.10.51:10000')
@@ -133,21 +132,32 @@ addEntertainChannel ('rtp://@239.35.10.44:10000', 'WDR Wuppertal', year='1956', 
 # -- Kultur
 addEntertainChannel ('rtp://@239.35.10.6:10000', '3sat', year='1984', genre=language(30092), plot=language(30111), all='3sat.jpg', hdurl='rtp://@239.35.10.47:10000')
 addEntertainChannel ('rtp://@239.35.10.20:10000', 'ARTE', year='1991', genre=language(30092), plot=language(30112), all='arte.jpg', hdurl='rtp://@239.35.10.3:10000')
-addEntertainChannel ('rtp://@239.35.10.21:10000', 'Einsfestival', year='1997', genre=language(30092), plot=language(30113))
+addEntertainChannel ('rtp://@239.35.10.21:10000', 'Einsfestival', year='1997', genre=language(30092), plot=language(30113), hdurl='rtp://@239.35.10.58:10000')
 addEntertainChannel ('rtp://@239.35.10.23:10000', 'zdf.kultur', year='2011', genre=language(30092), plot=language(30114), hdurl='rtp://@239.35.10.54:10000')
 
 # -- Special Interest
 addEntertainChannel ('rtp://@239.35.10.19:10000', 'KiKa', year='1997', genre=language(30093), plot=language(30115), hdurl='rtp://@239.35.10.11:10000')
 addEntertainChannel ('rtp://@239.35.10.22:10000', 'PHOENIX', year='1997', genre=language(30093), plot=language(30116), hdurl='rtp://@239.35.10.48:10000')
 addEntertainChannel ('rtp://@239.35.10.24:10000', 'BR-alpha', year='1998', genre=language(30093), plot=language(30117))
-addEntertainChannel ('rtp://@239.35.10.26:10000', 'EinsPlus', year='1997', genre=language(30093), plot=language(30118))
+addEntertainChannel ('rtp://@239.35.10.26:10000', 'EinsPlus', year='1997', genre=language(30093), plot=language(30118), hdurl='rtp://@239.35.10.59:10000')
 
 # -- Nachrichten
 addEntertainChannel ('rtp://@239.35.20.44:10000', 'Deutsche Welle', year='1992', genre=language(30094), plot=language(30120))
-addEntertainChannel ('rtp://@239.35.10.25:10000', 'tagesschau24', year='1997', genre=language(30094), plot=language(30121))
+addEntertainChannel ('rtp://@239.35.10.25:10000', 'tagesschau24', year='1997', genre=language(30094), plot=language(30121), hdurl='rtp://@239.35.10.63:10000')
 addEntertainChannel ('rtp://@239.35.10.28:10000', 'ZDFinfo', year='1997', genre=language(30094), plot=language(30122), hdurl='rtp://@239.35.10.56:10000')
-addEntertainChannel ('rtp://@239.35.10.27:10000', 'ZDFneo', year='2009', genre=language(30094), plot=language(30123))
+addEntertainChannel ('rtp://@239.35.10.27:10000', 'ZDFneo', year='2009', genre=language(30094), plot=language(30123), hdurl='rtp://@239.35.10.55:10000')
 
+# -- RTL Gruppe
+addEntertainChannel ('rtp://@239.35.20.10:10000', 'RTL', year='1984', genre=language(30090), plot=language(30130))
+addEntertainChannel ('rtp://@239.35.20.11:10000', 'VOX', year='1993', genre=language(30090), plot=language(30131))
+addEntertainChannel ('rtp://@239.35.20.22:10000', 'RTL II', year='1993', genre=language(30090), plot=language(30132))
+addEntertainChannel ('rtp://@239.35.20.39:10000', 'Super RTL', year='1995', genre=language(30093), plot=language(30133))
+addEntertainChannel ('rtp://@239.35.20.47:10000', 'n-tv', year='1992', genre=language(30094), plot=language(30134))
+addEntertainChannel ('rtp://@239.35.20.59:10000', 'RTLNITRO', year='2012', genre=language(30093), plot=language(30135))
+addEntertainChannel ('rtp://@239.35.20.5:10000', 'RTL NRW', year='1984', genre=language(30091), plot=language(30130))
+addEntertainChannel ('rtp://@239.35.20.6:10000', 'RTL HB NDS', year='1984', genre=language(30091), plot=language(30130))
+addEntertainChannel ('rtp://@239.35.20.63:10000', 'RTL HH SH', year='1984', genre=language(30091), plot=language(30130))
+addEntertainChannel ('rtp://@239.35.20.64:10000', 'RTL Hessen', year='1984', genre=language(30091), plot=language(30130))
 
 
 xbmcplugin.endOfDirectory(int(sys.argv[1]))

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -41,11 +41,11 @@
 	<string id="30127">	</string>
 	<string id="30128">	</string>
 	<string id="30129">	</string>
-	<string id="30130">	</string>
-	<string id="30131">	</string>
-	<string id="30132">	</string>
-	<string id="30133">	</string>
-	<string id="30134">	</string>
+	<string id="30130">RTL Television (formerly RTL plus), or simply RTL, is a German commercial television station distributed via cable and satellite, as well as via digital terrestrial (DVB-T) in more highly populated areas. It is owned by the RTL Group and is, in terms of market share, Germany's largest private free-to-air broadcaster.</string>
+	<string id="30131">VOX or Vox is a German television channel, headquartered in Cologne and part of the RTL Group, Europe's second largest TV, radio, and production company. The channel officially launched at 5:00pm on January 25, 1993. Prior to that, test transmissions had been made using the informal name Westschienenkanal (West slot channel, a reference to Nordschienenkanal and Südschienenkanal, the informal names used in the 1980s for the other two German private channels RTL Television and Sat.1). The channel mainly broadcasts documentaries and U.S. series and movies.</string>
+	<string id="30132">RTL II is a commercial, privately owned, general-interest German television channel. In 2012 the channel had a market share of 4% among viewers aged over three.</string>
+	<string id="30133">Super RTL is a Cologne-based German television network operated by RTL Disney Fernsehen GmbH & Co. KG. It was the second German television channel aimed mostly at children (the first was Nickelodeon and Cartoon Network). It was launched in 1995 as a joint venture between RTL Group predecessor company Compagnie Luxembourgeoise de Télédiffusion and The Walt Disney Company.</string>
+	<string id="30134">n-tv is a German television news channel owned by the Bertelsmann AG Media's RTL Group and an affiliate network of CNN since the networks creation in 1992. n-tv screens news bulletins on the hour and half hour; in between, it broadcasts informational programmes and advertising.</string>
 	<string id="30135">	</string>
 	<string id="30136">	</string>
 	<string id="30137">	</string>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -41,11 +41,11 @@
 	<string id="30127">	</string>
 	<string id="30128">	</string>
 	<string id="30129">	</string>
-	<string id="30130">	</string>
-	<string id="30131">	</string>
-	<string id="30132">	</string>
-	<string id="30133">	</string>
-	<string id="30134">	</string>
+	<string id="30130">RTL Television (ursprünglich auf Sendung gegangen unter dem Namen RTL plus), kurz RTL, ist ein deutschsprachiger Privatsender der RTL Group mit Sitz in Köln. Entstanden ist RTL als Ableger des deutschsprachigen Radioprogramms Radio Luxemburg. Aus diesem Grunde gab es in den ersten Jahren noch den Senderzusatz plus. RTL Television gilt in Deutschland als Vollprogramm nach dem 2. Rundfunkstaatsvertrag und beschäftigt heute nach Auslagerung der Nachrichten und der Technik ca. 500 fest angestellte Mitarbeiter (Stand: 8/2010).</string>
+	<string id="30131">VOX ist ein deutschsprachiger Privatsender der RTL Group mit Sitz in Köln, der aus dem Westschienenkanal Film- und Fernseh-GmbH & Co. KG hervorging. Diesem wurde am 20. November 1991 nach dem Satellitenstaatsvertrag (SatStV) eine Teillizenz zur Veranstaltung eines Fernsehvollprogramms gemeinsam mit der DCTP (Development Company for Television Program) erteilt. Seit dem 1. Januar 2011 hält VOX die Sendelizenz alleine. VOX gehört seit 1999 dem deutschen Senderverbund der Mediengruppe RTL Deutschland an. IP Deutschland ist das Vermarktungsunternehmen von VOX. Es verkauft unter anderem die Werbezeiten.</string>
+	<string id="30132">RTL II ist ein deutschsprachiger Fernsehsender, der von der RTL2 Fernsehen GmbH & Co. KG betrieben wird. RTL II ist gemäß dem Rundfunkstaatsvertrag ein privater Fernsehsender mit Vollprogramm. Für Österreich und die Schweiz werden Varianten des Hauptprogramms mit national eingefügten Werbeinseln produziert; diese Varianten sind über die Kabelnetze in diesen beiden Ländern sowie über Digitalsatellit zu empfangen. RTL II ist in Deutschland der zweite Ableger der RTL Group.</string>
+	<string id="30133">Super RTL ist ein Spartensender der RTL Group, der sich hauptsächlich an Kinder und Jugendliche richtet. Super RTL sieht sich selbst als Familiensender. Seit Februar 1998 ist Super RTL Marktführer bei den 3- bis 13-Jährigen und hat in dieser Zielgruppe einen Marktanteil von 24 Prozent.</string>
+	<string id="30134">n-tv ist ein von der n-tv Nachrichtenfernsehen GmbH betriebener Nachrichtensender, der zur RTL Group gehört. Am 30. November 1992 startete n-tv in Berlin nach DW-TV als zweiter deutscher TV-Nachrichtensender. Seit der Jahrtausendwende hat der Anteil der Nachrichten kontinuierlich zugunsten von Infotainment und Dokumentationen abgenommen.</string>
 	<string id="30135">	</string>
 	<string id="30136">	</string>
 	<string id="30137">	</string>

--- a/resources/language/Italian/strings.xml
+++ b/resources/language/Italian/strings.xml
@@ -41,10 +41,10 @@
 	<string id="30127">	</string>
 	<string id="30128">	</string>
 	<string id="30129">	</string>
-	<string id="30130">	</string>
+	<string id="30130">RTL (fino al 1992 RTL plus) è una rete televisiva privata tedesca che trasmette in Germania sulle frequenze terrestri e sul DVB-T (Digitale terrestre), visibile gratuitamente nel resto d'Europa grazie al satellite Astra. Attualmente è l'emittente privata tedesca che ottiene gli ascolti più alti, ed è la più grande d'Europa.</string>
 	<string id="30131">	</string>
 	<string id="30132">	</string>
-	<string id="30133">	</string>
+	<string id="30133">Super RTL è una rete televisiva tedesca con programmazione rivolta esclusivamente ai bambini e ragazzi, con programmi Disney ed autoprodotti; la sera ripropone vecchi show prodotti dal gruppo RTL Germania. L'emittente di notte manda in onda televendite o un monoscopio con un camino acceso e della legna sul fuoco.</string>
 	<string id="30134">	</string>
 	<string id="30135">	</string>
 	<string id="30136">	</string>


### PR DESCRIPTION
Added:
hr-fernsehen HD, MDR Sachsen HD, rbb Berlin HD, Einsfestival HD,
EinsPlus HD, tagesschau24 HD, ZDFneo HD, RTL (with 4 regional channels),
VOX, RTL II, Super RTL and n-tv

Merged 'NDR Niedersachsen' and 'MDR Niedersachsen HD' into one channel
with SD- and HD-url.

Also added german, english and some italian channel descriptions for the
'RTL-Group' channels.

Source:
http://grinch.itg-em.de/entertain/faq/allgemein/multicastadressliste/
